### PR TITLE
Jupyter report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ obj
 secrets.*.tfvars
 .terraform*
 *.tfstate*
+.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ At the end of the run make sure all messages are delivered (ex. by calling produ
 At the end of the run make sure you produce a log starting with "REPORT" keyword, this will be displayed at when executing scenarios.
 Example:
 ```java
-    logger.info("REPORT: Produced %s with %s ProduceRequest in %s", lastTotalMsgsMetric, lastRequestCount, str(timedelta(seconds=end_time - start_time)))
+    logger.info("REPORT: Produced %s with %s ProduceRequests in %s", lastTotalMsgsMetric, lastRequestCount, str(timedelta(seconds=end_time - start_time)))
 ```
 
 ### My client is ready, how can I plug it in the test suite ?

--- a/README.md
+++ b/README.md
@@ -118,16 +118,15 @@ This will help to play with batch.size/linger.ms/etc...
 By default each client implementation will need to capture metrics at regular interval (defined via REPORTING_INTERVAL).
 The should be logged using the following format to make things easier to compare: 
 ```java
-        logger.info("Sent rate = {}/sec, duration spent in queue = {}ms, batch size = {}, request rate = {}/sec, request latency avg = {}ms, records per ProduceRequest = {}", avgSendRate, queueTimeAvg, batchSizeAvg, requestRate, requestLatencyAvg, recordsPerRequestAvg);
-
+logger.info("Sent rate = {}/sec, duration spent in queue = {}ms, batch size = {}, request rate = {}/sec, request latency avg = {}ms, records per ProduceRequest = {}", avgSendRate, queueTimeAvg, batchSizeAvg, requestRate, requestLatencyAvg, recordsPerRequestAvg);
 ```
 
 At the end of the run make sure all messages are delivered (ex. by calling producer.flush().
 
 At the end of the run make sure you produce a log starting with "REPORT" keyword, this will be displayed at when executing scenarios.
 Example:
-```java
-    logger.info("REPORT: Produced %s with %s ProduceRequests in %s", lastTotalMsgsMetric, lastRequestCount, str(timedelta(seconds=end_time - start_time)))
+```python
+logger.info("REPORT: Produced %s with %s ProduceRequests in %s ms", lastTotalMsgsMetric, lastRequestCount, str(round(delta)))
 ```
 
 ### My client is ready, how can I plug it in the test suite ?

--- a/bench-initializer/pom.xml
+++ b/bench-initializer/pom.xml
@@ -41,7 +41,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>com.sample.BenchmarkProducer</mainClass>
+                            <mainClass>com.sample.BenchmarkInitializer</mainClass>
                             <addClasspath>true</addClasspath>
                         </manifest>
                     </archive>

--- a/dotnet-producer/benchmark.cs
+++ b/dotnet-producer/benchmark.cs
@@ -61,8 +61,8 @@ class ProducerBenchmark {
             producer.Flush();
             timer.Stop();
             TimeSpan duration = timer.Elapsed;
-            string durationAsString = String.Format("{0:00}:{1:00}:{2:00}.{3}", duration.Hours, duration.Minutes, duration.Seconds, duration.Milliseconds);
-            logger.LogInformation("REPORT: Produced {lastTotalMsgsMetric} with {lastRequestCount} ProduceRequests in {durationAsString}",producer.lastMetricCollectionTimestamp,producer.lastRequestCount,durationAsString);
+            long durationMs = Math.Max(0L, (long)duration.TotalMilliseconds);
+            logger.LogInformation("REPORT: Produced {lastTotalMsgsMetric} with {lastRequestCount} ProduceRequests in {durationAsString} ms",producer.lastMetricCollectionTimestamp,producer.lastRequestCount,durationMs);
 
         }
     }

--- a/golang-producer/main.go
+++ b/golang-producer/main.go
@@ -159,5 +159,5 @@ func main() {
 	elapsed := time.Since(start)
 
 	p.Close()
-	log.Printf("REPORT: Produced %d with %d ProduceRequest in %s", statsMetrics.LastTotalMsgsMetric, statsMetrics.LastRequestCount, elapsed)
+	log.Printf("REPORT: Produced %d with %d ProduceRequests in %s", statsMetrics.LastTotalMsgsMetric, statsMetrics.LastRequestCount, elapsed)
 }

--- a/golang-producer/main.go
+++ b/golang-producer/main.go
@@ -159,5 +159,5 @@ func main() {
 	elapsed := time.Since(start)
 
 	p.Close()
-	log.Printf("REPORT: Produced %d with %d ProduceRequests in %s", statsMetrics.LastTotalMsgsMetric, statsMetrics.LastRequestCount, elapsed)
+	log.Printf("REPORT: Produced %d with %d ProduceRequests in %d ms", statsMetrics.LastTotalMsgsMetric, statsMetrics.LastRequestCount, elapsed.Milliseconds())
 }

--- a/java-producer/src/main/java/com/sample/Injector.java
+++ b/java-producer/src/main/java/com/sample/Injector.java
@@ -139,7 +139,7 @@ public class Injector {
         double totalMsgsMetric = producerMetric(metrics, "record-send-total");
         double requestTotal = producerMetric(metrics, "request-total");
         String duration = DurationFormatUtils.formatDurationHMS(Instant.now().toEpochMilli() - startTime.toEpochMilli());
-        logger.info("REPORT: Produced {} with {} ProduceRequest in {}", totalMsgsMetric, requestTotal, duration);
+        logger.info("REPORT: Produced {} with {} ProduceRequests in {}", totalMsgsMetric, requestTotal, duration);
     }
 
     private void sendCallback(ProducerRecord<String, String> record, RecordMetadata recordMetadata, Exception e) {

--- a/java-producer/src/main/java/com/sample/Injector.java
+++ b/java-producer/src/main/java/com/sample/Injector.java
@@ -138,8 +138,8 @@ public class Injector {
         Map<MetricName, ? extends Metric> metrics = producer.metrics();
         double totalMsgsMetric = producerMetric(metrics, "record-send-total");
         double requestTotal = producerMetric(metrics, "request-total");
-        String duration = DurationFormatUtils.formatDurationHMS(Instant.now().toEpochMilli() - startTime.toEpochMilli());
-        logger.info("REPORT: Produced {} with {} ProduceRequests in {}", totalMsgsMetric, requestTotal, duration);
+        Long duration = Instant.now().toEpochMilli() - startTime.toEpochMilli();
+        logger.info("REPORT: Produced {} with {} ProduceRequests in {} ms", totalMsgsMetric, requestTotal, duration);
     }
 
     private void sendCallback(ProducerRecord<String, String> record, RecordMetadata recordMetadata, Exception e) {

--- a/python-producer/benchmark-producer.py
+++ b/python-producer/benchmark-producer.py
@@ -102,7 +102,7 @@ def main():
         producer.flush()
 
         end_time = time.monotonic()
-        logger.info("REPORT: Produced %s with %s ProduceRequest in %s", lastTotalMsgsMetric, lastRequestCount, str(timedelta(seconds=end_time - start_time)))
+        logger.info("REPORT: Produced %s with %s ProduceRequests in %s", lastTotalMsgsMetric, lastRequestCount, str(timedelta(seconds=end_time - start_time)))
     except BaseException as e:
         logger.info("Something bad happened : %s", str(e))
     finally:

--- a/python-producer/benchmark-producer.py
+++ b/python-producer/benchmark-producer.py
@@ -102,7 +102,8 @@ def main():
         producer.flush()
 
         end_time = time.monotonic()
-        logger.info("REPORT: Produced %s with %s ProduceRequests in %s", lastTotalMsgsMetric, lastRequestCount, str(timedelta(seconds=end_time - start_time)))
+        delta = timedelta(seconds=end_time - start_time).total_seconds() * 1000
+        logger.info("REPORT: Produced %s with %s ProduceRequests in %s ms", lastTotalMsgsMetric, lastRequestCount, str(round(delta)))
     except BaseException as e:
         logger.info("Something bad happened : %s", str(e))
     finally:

--- a/report/Dockerfile
+++ b/report/Dockerfile
@@ -3,8 +3,8 @@
  ARG UID=1000
  ARG GID=1000
  USER root
- RUN groupadd -g $GID jovyan
- RUN usermod -u $UID -g $GID jovyan 
+ RUN groupadd -o -g $GID jovyan
+ RUN usermod -u $UID -g $GID jovyan
  USER jovyan
  RUN pip install plotly kaleido
  CMD jupyter nbconvert work/benchmark-report.ipynb --execute --to markdown --output report.md --no-input

--- a/report/Dockerfile
+++ b/report/Dockerfile
@@ -1,0 +1,10 @@
+ FROM jupyter/datascience-notebook
+ # necessary as we will be producing files within the container
+ ARG UID=1000
+ ARG GID=1000
+ USER root
+ RUN groupadd -g $GID jovyan
+ RUN usermod -u $UID -g $GID jovyan 
+ USER jovyan
+ RUN pip install plotly kaleido
+ CMD jupyter nbconvert work/benchmark-report.ipynb --execute --to markdown --output report.md --no-input

--- a/report/benchmark-report.ipynb
+++ b/report/benchmark-report.ipynb
@@ -1,0 +1,251 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75bbf82e-54ac-4da3-811b-be3f6901caa6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import plotly.express as px\n",
+    "import plotly.io as pio\n",
+    "\n",
+    "#necessary if we want to export report as markdown files\n",
+    "pio.renderers.default = \"png\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "111901a7-60a6-4d61-aaf2-9700d01f5ad0",
+   "metadata": {},
+   "source": [
+    "# Scenario configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7de412b7-73d3-4ee8-a37a-af99c08ea736",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "with open('scenario.env') as f:\n",
+    "    contents = f.read()\n",
+    "    print(contents)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "008bc7ea-adbd-4e4e-959d-59e5bc898af4",
+   "metadata": {},
+   "source": [
+    "# Metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31afa99c-b613-4e50-b490-978c1ffebd78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('metrics.csv')\n",
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a975b9df-3c45-467d-8683-41fc089f9a3b",
+   "metadata": {},
+   "source": [
+    "## Sent rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5226db0-8faa-429b-80dd-b376ae0ae40e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.line(df, x = 'Index',  y = 'Sent rate', color='ProducerType')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54ebb65e-8709-45ae-a3c1-98e0f390dfa0",
+   "metadata": {},
+   "source": [
+    "## Duration spent in queue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "911a9a96-3362-4339-8af7-47bd7e5597bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.line(df, x = 'Index',  y = 'duration spent in queue', color='ProducerType')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e451797-813f-453e-99c7-997b7ac303d3",
+   "metadata": {},
+   "source": [
+    "## Batch size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f15699cd-8abe-4b9b-a08c-f5e890e31de1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.line(df, x = 'Index',  y = 'batch size', color='ProducerType')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8921fcf5-07d1-4b89-b7df-795b12d11b78",
+   "metadata": {},
+   "source": [
+    "## Request Rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec816012-db63-4093-b167-8c3a5bcdd980",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.line(df, x = 'Index',  y = 'request rate', color='ProducerType')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f4afe9c-4402-4169-ae67-9a35b1334cd1",
+   "metadata": {},
+   "source": [
+    "## Request latency Average"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74adc211-5a99-4715-91d9-16d7f73d4699",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.line(df, x = 'Index',  y = 'request latency avg', color='ProducerType')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "417706ba-3db7-4841-9866-6478809c663a",
+   "metadata": {},
+   "source": [
+    "# Overall stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aff02a4a-59f8-459b-b55c-39d2495090f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_final_results = pd.read_csv('final-results.csv')\n",
+    "print(df_final_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e18f636-692f-4d30-b89b-75e38375861c",
+   "metadata": {},
+   "source": [
+    "## Number of messages sent in total"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72aa90a9-9748-4a67-a750-8dbae1fc657d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.bar(df_final_results, x = 'ProducerType', y = 'nb_msgs', color='ProducerType')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f0e3ac3-fc25-4bf8-bc11-3600afc3fdf6",
+   "metadata": {},
+   "source": [
+    "## Number of request sent in total"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0d28fd1-9ca9-435c-9acb-0ea18f43bae5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.bar(df_final_results, x = 'ProducerType', y = 'nb_requests', color='ProducerType')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7b44320-5c17-41e7-bca2-86845a8d0feb",
+   "metadata": {},
+   "source": [
+    "## Duration in seconds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdd28a16-fe72-4af8-818d-94d31c5ecc06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = px.bar(df_final_results, x = 'ProducerType', y = 'duration', color='ProducerType')\n",
+    "fig.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/report/benchmark-report.ipynb
+++ b/report/benchmark-report.ipynb
@@ -12,7 +12,8 @@
     "import plotly.io as pio\n",
     "\n",
     "#necessary if we want to export report as markdown files\n",
-    "pio.renderers.default = \"png\""
+    "pio.renderers.default = \"png\"\n",
+    "language_colors={\"dotnet\": \"#178600\", \"golang\": \"#00ADD8\", \"java\": \"#b07219\", \"python\": \"#3572A5\", \"rust\": \"#dea584\"}"
    ]
   },
   {
@@ -70,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = px.line(df, x = 'Index',  y = 'Sent rate', color='ProducerType')\n",
+    "fig = px.line(df, x = 'Index',  y = 'Sent rate', color='ProducerType', color_discrete_map=language_colors)\n",
     "fig.show()"
    ]
   },
@@ -89,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = px.line(df, x = 'Index',  y = 'duration spent in queue', color='ProducerType')\n",
+    "fig = px.line(df, x = 'Index',  y = 'duration spent in queue', color='ProducerType', color_discrete_map=language_colors)\n",
     "fig.show()"
    ]
   },
@@ -108,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = px.line(df, x = 'Index',  y = 'batch size', color='ProducerType')\n",
+    "fig = px.line(df, x = 'Index',  y = 'batch size', color='ProducerType', color_discrete_map=language_colors)\n",
     "fig.show()"
    ]
   },
@@ -127,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = px.line(df, x = 'Index',  y = 'request rate', color='ProducerType')\n",
+    "fig = px.line(df, x = 'Index',  y = 'request rate', color='ProducerType', color_discrete_map=language_colors)\n",
     "fig.show()"
    ]
   },
@@ -146,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = px.line(df, x = 'Index',  y = 'request latency avg', color='ProducerType')\n",
+    "fig = px.line(df, x = 'Index',  y = 'request latency avg', color='ProducerType', color_discrete_map=language_colors)\n",
     "fig.show()"
    ]
   },
@@ -184,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = px.bar(df_final_results, x = 'ProducerType', y = 'nb_msgs', color='ProducerType')\n",
+    "fig = px.bar(df_final_results, x = 'ProducerType', y = 'nb_msgs', color='ProducerType', color_discrete_map=language_colors)\n",
     "fig.show()"
    ]
   },
@@ -203,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = px.bar(df_final_results, x = 'ProducerType', y = 'nb_requests', color='ProducerType')\n",
+    "fig = px.bar(df_final_results, x = 'ProducerType', y = 'nb_requests', color='ProducerType', color_discrete_map=language_colors)\n",
     "fig.show()"
    ]
   },
@@ -222,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = px.bar(df_final_results, x = 'ProducerType', y = 'duration', color='ProducerType')\n",
+    "fig = px.bar(df_final_results, x = 'ProducerType', y = 'duration', color='ProducerType', color_discrete_map=language_colors)\n",
     "fig.show()"
    ]
   }

--- a/report/docker-compose.yml
+++ b/report/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  notebook:
+    build: .
+    ports:
+      - "8888:8888"
+    environment:
+      - JUPYTER_ENABLE_LAB=yes
+    volumes:
+      - ../results:/home/jovyan/work
+    command: start-notebook.sh --NotebookApp.token=''

--- a/report/extract_results.py
+++ b/report/extract_results.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import re
+import sys
+from os import listdir
+from os.path import isfile, join
+
+extracted_metrics = [
+    'Sent rate',
+    'duration spent in queue',
+    'batch size',
+    'request rate',
+    'request latency avg',
+    'records per ProduceRequest'
+]
+metric_patterns = [fr"{metric}\s*=\s*(NaN|\d*\.?\d*)" for metric in extracted_metrics]
+metrics_pattern = re.compile('.*' + '.*'.join(metric_patterns))
+report_pattern = re.compile(r'.*REPORT.*\s*Produced\s*(\d+?\.?\d+)\s+with\s+(\d+?\.?\d+)\s+ProduceRequests\s+in\s+(.*)')
+file_lang_pattern = re.compile('.*/(.*)-producer.*[.]txt')
+
+
+def main(args):
+    results_folder = args[0]
+    metric_output_csv= join(results_folder, 'metrics.csv')
+    with open(metric_output_csv, 'w') as f:
+        print("ProducerType,Index,", end='', file=f)
+        print(','.join(extracted_metrics), file=f)
+
+    final_output_csv= join(results_folder, 'final-results.csv')
+    with open(final_output_csv, 'w') as f:
+        print("ProducerType,nb_msgs,nb_requests,duration",  file=f)
+
+
+    for file in listdir(results_folder):
+        fullpath = join(results_folder, file)
+        file_match = file_lang_pattern.fullmatch(fullpath)
+        if not isfile(fullpath) or file_match is None :
+            continue
+        producer_type = file_match.group(1)
+        metrics: list[tuple] = []
+        print(f"Generating metrics for {producer_type}")
+
+        report = extract_logs(fullpath, metrics)
+        if report:
+            csv_report(metric_output_csv, final_output_csv, producer_type, metrics, report)
+
+
+def extract_logs(file_name, metrics) -> tuple:
+    file = open(file_name, 'r')
+    for line in file.readlines():
+        if extract_metrics(line, metrics):
+            continue
+        report = extract_report(line)
+        if report:
+            return report
+    return ()
+
+
+def extract_metrics(line: str, metrics: list[tuple]):
+    res = metrics_pattern.fullmatch(line.strip())
+    if res is None:
+        return False
+    metrics.append(res.groups())
+    return True
+
+
+def extract_report(line: str):
+    res = report_pattern.fullmatch(line.strip())
+    if res is None:
+        return ()
+    return res.groups()
+
+
+def csv_report(metric_output_csv: str, final_output_csv: str, producer_type: str,  metrics: list[tuple], report: tuple):
+    with open(metric_output_csv, 'a') as f:
+        i = 0
+        for metric in metrics:
+            ignore = True
+            for m in metric:
+                if ignore and not (m == 0 or m == 'NaN' or m == 0.0 or m == '0' or m == '0.0'):
+                    ignore = False
+            if not ignore:
+                print(producer_type+',' + str(i) + ',', file=f, end='')
+                print(','.join(metric), file=f)
+                i += 1 
+
+    with open(final_output_csv, 'a') as f:
+        print(producer_type+',', file=f, end='')
+        print(','.join(report), file=f)
+
+# ENTRYPOINT
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/report/extract_results.py
+++ b/report/extract_results.py
@@ -14,7 +14,7 @@ extracted_metrics = [
 ]
 metric_patterns = [fr"{metric}\s*=\s*(NaN|\d*\.?\d*)" for metric in extracted_metrics]
 metrics_pattern = re.compile('.*' + '.*'.join(metric_patterns))
-report_pattern = re.compile(r'.*REPORT.*\s*Produced\s*(\d+?\.?\d+)\s+with\s+(\d+?\.?\d+)\s+ProduceRequests\s+in\s+(.*)')
+report_pattern = re.compile(r'.*REPORT.*\s*Produced\s*(\d+?\.?\d+)\s+with\s+(\d+?\.?\d+)\s+ProduceRequests\s+in\s+(.*)ms.*')
 file_lang_pattern = re.compile('.*/(.*)-producer.*[.]txt')
 
 

--- a/run-jupiter.sh
+++ b/run-jupiter.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+SCRIPTDIR=$(basename $SCRIPTPATH)
+
+source utils.sh
+
+cd ${BENCH_ROOT_DIR}/report
+docker-compose up -d --build
+
+echo "Jupiter is available http://localhost:8888"
+echo "You can load the notebookd in work/{SCENARIO}/benchmark-report.ipynb"
+
+read -p "Press enter to stop jupiter"
+docker-compose down -v

--- a/rust-producer-sync/src/main.rs
+++ b/rust-producer-sync/src/main.rs
@@ -122,7 +122,7 @@ fn main() {
     let stats = stats_arc.lock().unwrap();
     let seconds = elapsed.num_seconds();
     info!(
-        "REPORT: Produced {} with {} ProduceRequest in {:.2}:{:.2}:{:.2}.{:.3}",
+        "REPORT: Produced {} with {} ProduceRequests in {:.2}:{:.2}:{:.2}.{:.3}",
         stats.nb_msgs_sent,
         stats.request_count,
         seconds / 60 / 60,

--- a/rust-producer-sync/src/main.rs
+++ b/rust-producer-sync/src/main.rs
@@ -120,15 +120,11 @@ fn main() {
     producer.flush(Duration::from_secs(30));
     let elapsed = Utc::now() - start;
     let stats = stats_arc.lock().unwrap();
-    let seconds = elapsed.num_seconds();
     info!(
-        "REPORT: Produced {} with {} ProduceRequests in {:.2}:{:.2}:{:.2}.{:.3}",
+        "REPORT: Produced {} with {} ProduceRequests in {} ms",
         stats.nb_msgs_sent,
         stats.request_count,
-        seconds / 60 / 60,
-        seconds / 60 % 60,
-        seconds % 60,
-        elapsed.num_milliseconds() % (seconds * 1000)
+        elapsed.num_milliseconds()
     );
 }
 

--- a/utils.sh
+++ b/utils.sh
@@ -2,8 +2,7 @@
 
 NETWORK_NAME=benchmark-producer-network
 PRODUCER_IMAGES=("java-producer" "python-producer" "dotnet-producer" "rust-producer-sync" "golang-producer")
-BENCH_ROOT_DIR=$( dirname $(realpath ${BASH_SOURCE[0]}))
-
+BENCH_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 docker_compose_file=${docker_compose_file:-docker-compose-3-brokers.yml}
 


### PR DESCRIPTION
This PR basically add some python script to produce CSV files for all producer implementations and then use Jupiter to generate markdown report in results/${SCENARIO}/report.md.

In addition to this there is a new script call `run-jupiter.sh` that start jupiter web-ui on http://localhost:8888, so you can hack and play with the notebooks.